### PR TITLE
Adding access to the spawned process' stdout stream

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,14 @@ module.exports = {
 
   restore : function(opts) {
     var spawn = new Spawn("mongorestore", opts);
-  }
+  },
+
+  export : function(opts) {
+    var spawn = new Spawn("mongoexport", opts);
+  },
+
+  import : function(opts) {
+    var spawn = new Spawn("mongoimport", opts);
+  }  
 
 };

--- a/index.js
+++ b/index.js
@@ -6,18 +6,22 @@ module.exports = {
 
   dump : function(opts) {
     var spawn = new Spawn("mongodump", opts);
+    return spawn;
   },
 
   restore : function(opts) {
     var spawn = new Spawn("mongorestore", opts);
+    return spawn;
   },
 
   export : function(opts) {
     var spawn = new Spawn("mongoexport", opts);
+    return spawn;
   },
 
   import : function(opts) {
     var spawn = new Spawn("mongoimport", opts);
-  }  
+    return spawn;
+  }
 
 };

--- a/libs/spawn.js
+++ b/libs/spawn.js
@@ -15,6 +15,6 @@ module.exports = function(cmd, opts) {
     else if(opts[prop] !== false) args.push('--' + prop + '=' + opts[prop]);
   }
 
-  return spawn(cmd, args, { stdio: [ process.stdin, process.stdout, process.stderr ] });
+  return spawn(cmd, args, { stdio: [ process.stdin, 'pipe', process.stderr ] });
 
 };

--- a/tasks/mongobackup.js
+++ b/tasks/mongobackup.js
@@ -9,9 +9,9 @@ module.exports = function(manager) {
     var opts = this.options();
     var task = this.target;
 
-    if(['dump','restore'].indexOf(task) === -1) {
+    if(['dump','restore', 'export', 'import'].indexOf(task) === -1) {
 
-      manager.log.writeln("Invalid argument passed: available options are 'mongobackup:dump' and 'mongobackup:restore'");
+      manager.log.writeln("Invalid argument passed: available options are 'mongobackup:dump', 'mongobackup:restore', 'mongobackup:export' and 'mongobackup:import'");
       return;
 
     } else {


### PR DESCRIPTION
This PR adds two things:
1. support for `mongoexport` and `mongoimport` (thanks to @seogrady!)
2. support for accessing the output of a task as a separate stream. This allows the use of gulp plugins to access, modify and redirect the output. In my case, I'm running an export to csv, piping it to a csv parser to parse the output and modify a field, and then writing the entire file to disk using `gulp.dest()`.

For example:
```js
var collectionExport = mongobackup.export({
	/* snip: host/username/password config */
	collection: 'ACollection',
	fields: 'a,list,of,fields',
	type : 'csv'
});

// Wrap in a vinyl stream and use Gulp to write to file
return collectionExport.stdout
	.pipe(source('export.csv')) // Use vinyl-source-stream to wrap in a vinyl stream
	.pipe(gulp.dest('./')); // Writes to './export.csv'
```

I'm not sure if changing the ChildProcess' output from the parent's `process.stdout` to its own stream is a big deal or not, but it's a potentially breaking change.

Thanks for this useful project!